### PR TITLE
added communication links

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
                             <ul>
                                 <li>Hardware for PSLab: <span style="color: #e12b00;"><a style="color: #e12b00;" href="https://github.com/fossasia/pslab-hardware" target="_blank">github.com/fossasia/pslab-hardware</a> </span></li>                                
                                 <li>Firmware for PSLab: <span style="color: #e12b00;"><a style="color: #e12b00;" href="https://github.com/fossasia/pslab-firmware" target="_blank">github.com/fossasia/pslab-firmware</a> </span></li>
-                                <li>Android App for PSLab: <span style="color: #e12b00;"><a style="color: #e12b00;" href="https://github.com/fossasia/pslab-android" target="_blank">github.com/fossasia/pslab</a> </span></li>
+                                <li>Android App for PSLab: <span style="color: #e12b00;"><a style="color: #e12b00;" href="https://github.com/fossasia/pslab-android" target="_blank">github.com/fossasia/pslab-android</a> </span></li>
                                 <li>Python Library for PSLab: <span style="color: #e12b00;"><a style="color: #e12b00;" href="https://github.com/fossasia/pslab-python" target="_blank">github.com/fossasia/pslab-python</a>  </span></li>
                                 <li>PSLab-Apps for Qt based GUI programs, widgets and templates for various experiments using Python: <span style="color: #e12b00;"><a style="color: #e12b00;" href="https://github.com/fossasia/pslab-dekstop-apps" target="_blank">github.com/fossasia/pslab-desktop-apps</a>  </span></li>
                             </ul>
@@ -200,9 +200,9 @@
 			pyopengl and qt-opengl   #for 3D graphics
 			iPython-qtconsole        #optional</pre>
                             <p>Now clone both the repositories <span style="color: #e12b00;"><a style="color: #e12b00;" href="https://github.com/fossasia/pslab-desktop-apps" target="_blank">pslab-desktop-apps</a></span> and <span style="color: #e12b00;"><a style="color: #e12b00;" href="https://github.com/fossasia/pslab-python" target="_blank">pslab-python</a></span> </p>
-                            Libraries must be installed in the following order
-                            <p style="padding-left: 120px;">1. pslab-apps</p>
-                            <p style="padding-left: 120px;">2. pslab</p>
+                            Libraries must be installed in the following order :
+                            <p style="padding-left: 120px;">1. pslab-python</p>
+                            <p style="padding-left: 120px;">2. pslab-desktop-apps</p>
                             To install, cd into the directories
                             <pre class="plain-readme">$ cd &lt;SOURCE_DIR&gt;</pre> and run the following (for both the repos)
                             <pre class="plain-readme">$ sudo make clean</pre>
@@ -424,21 +424,28 @@
 <div class="container">
 
   <div class="col-lg-6">
-		<h2 style="">Contact</h2>
+		<h2 style="">Communication</h2>
 		<hr color="white">
 
     <div>
 			<i class="fa fa-info-circle" aria-hidden="true"></i> PSLab | FOSSASIA
 		</div>
-
     <div>
-  		<i class="fa fa-envelope" aria-hidden="true"></i>
-  		<a href="mailto: pslab@gmail.com">pslab@gmail.com</a>
+			<i class="fa fa-comments" aria-hidden="true"></i>		
+			<a href="https://gitter.im/fossasia/pslab">Gitter Chat Channel</a>
 		</div>
 
     <div class="slack">
 			<i class="fa fa-slack" aria-hidden="true"></i>
  			<a href=" https://fossasia.slack.com/messages/pocketscience/">Slack Channel</a> | <a href="http://fossasia-slack.herokuapp.com/">Get Invited!</a>
+		</div>
+    <div>
+  		<i class="fa fa-envelope" aria-hidden="true"></i>
+  		<a href="https://groups.google.com/forum/#!forum/pslab-fossasia">PSLab Mailing List</a>
+		</div>
+    <div>
+  		<i class="fa fa-envelope" aria-hidden="true"></i>
+  		<a href="https://groups.google.com/forum/#!forum/fossasia">FOSSASIA Mailing List</a>
 		</div>
   </div>
 


### PR DESCRIPTION
Fix #61 
Updated site with communication links and changed order of installation.
There is no fa icon for gitter, thus used some random chat icon.

![screenshot from 2017-04-17 16-28-01](https://cloud.githubusercontent.com/assets/12713808/25087299/74315c8e-238b-11e7-907a-593b5b29d145.png)
