### PR TITLE
Fix the styling of word `FOSSASIA` on page top left.

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -48,8 +48,7 @@
 }
 
 img.logo-navbar{
-  width: 150px;
-  float: left;
+  width: 130px;
   margin-top: 15px;
 }
 

--- a/index.html
+++ b/index.html
@@ -34,11 +34,11 @@
             <!-- Collect the nav links, forms, and other content for toggling -->
             <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
                 <a href="http://fossasia.org" id="light-logo" class="link-logo"><img src="img/fossasia-logo-light.png" alt="fossasia logo" class="logo-navbar" style="cursor: pointer;"></a>
-                <a href="http://fossasia.org" id="dark-logo" class="link-logo"><img src="img/fossasia-logo.png" alt="fossasia logo" class="logo-navbar" style="cursor: pointer;"></a>
+                <a href="http://fossasia.org" id="dark-logo" class="link-logo" style="display: none;"><img src="img/fossasia-logo.png" alt="fossasia logo" class="logo-navbar" style="cursor: pointer;"></a>
                 <ul class="nav navbar-nav navbar-right">
-                    <li id="fossasia-link">
+                    <!-- <li id="fossasia-link">
                         <a href="http://fossasia.org" target="_blank">FOSSASIA</a>
-                    </li>
+                    </li> -->
                     <li>
                         <a href="index.html" title="Home">Home</a>
                     </li>

--- a/js/sticky-header.js
+++ b/js/sticky-header.js
@@ -12,25 +12,53 @@ $(document).ready(function(){
 	    $('#sticky-navbar').removeClass('sticky');
 	}
 
-	if (scrollTop > 60) { 
-		$("#dark-logo").show();
+	// This runs only one time i.e., when page loads for the first time.
+	// After page is loaded, this code doesn't observe window's width changes
+	if($( window ).width() > 776){
+		// $("#fossasia-link").hide();
+
+		if (scrollTop > 60) {
+			$("#light-logo").hide();
+			$("#dark-logo").show();
+			$("#dark-logo").css("display", "block");
+			$('#sticky-navbar').addClass('sticked');
+		} else {
+			$("#dark-logo").hide();
+			$("#light-logo").show();
+			$('#sticky-navbar').removeClass('sticked');
+		}
+
+	}else if($( window ).width() < 776){
+		// $("#fossasia-link").show();
 		$("#light-logo").hide();
-	    $('#sticky-navbar').addClass('sticked');
-	} else {
-		$("#dark-logo").hide();
-		$("#light-logo").show();
-	    $('#sticky-navbar').removeClass('sticked');
+		$("#dark-logo").show();
+		$("#dark-logo").css("display", "block");
 	}
 	};
 
-	if($( window ).width() > 776){
-		$("#fossasia-link").hide();
 
-	}else if($( window ).width() < 776){
-		$("#fossasia-link").show();
-		$("#light-logo").remove();
-		$("#dark-logo").remove();
-	}
+	// Checks for width and scrollTop every time window's width changes
+	$(window).resize(() => {
+		if($( window ).width() > 776){
+			// $("#fossasia-link").hide();
+			
+			if ($(window).scrollTop() > 60) {
+				$("#light-logo").hide();
+				$("#dark-logo").show();
+				$("#dark-logo").css("display", "block");
+				$('#sticky-navbar').addClass('sticked');
+			}else {
+				$("#dark-logo").hide();
+				$("#light-logo").show();
+				$('#sticky-navbar').removeClass('sticked');
+			}
+		}else if($( window ).width() < 776){
+			// $("#fossasia-link").show();
+			$("#light-logo").hide();
+			$("#dark-logo").show();
+			$("#dark-logo").css("display", "block");
+		}
+	})
 
 	stickyNavBar();
 


### PR DESCRIPTION
When website is resized, styling of word FOSSASIA on
page top left is broken, especially when the navbar toggles.
This is happening due to the absence any listener for width
change event. Submitting a fix for it.

Fixes #95.