### PR TITLE
navbar logo made inline

### DIFF
--- a/js/sticky-header.js
+++ b/js/sticky-header.js
@@ -20,7 +20,7 @@ $(document).ready(function(){
 		if (scrollTop > 60) {
 			$("#light-logo").hide();
 			$("#dark-logo").show();
-			$("#dark-logo").css("display", "block");
+			$("#dark-logo").css("display", "inline-block");
 			$('#sticky-navbar').addClass('sticked');
 		} else {
 			$("#dark-logo").hide();


### PR DESCRIPTION
![old-nav](https://user-images.githubusercontent.com/34238240/42677922-eb17777a-869a-11e8-8b78-411339e95feb.png)

this is the current navbar which has logo as a block element pushing other elements on the next line.
now it is fixed and looks like

![nav](https://user-images.githubusercontent.com/34238240/42677978-1bf97226-869b-11e8-8c05-4f0a7af18c57.png)
